### PR TITLE
Fixes and update to the dataset and dataset status entry points

### DIFF
--- a/source/includes/_dataset_status.md
+++ b/source/includes/_dataset_status.md
@@ -18,9 +18,6 @@
 }
 ```
 
-<aside class="notice">
-This API needs to be refactored into something clearer.
-</aside>
 The dataset status describes the current state of a dataset, stating if it's published or not and the running operation. It is a finite state machine, with the following properties:
 
 * a single state at a time
@@ -38,7 +35,6 @@ Attribute | Description
 `published` <br> *boolean* | true if the dataset is available in the search API
 `name` <br> *string* | One of the dataset status values
 `since` <br> *datetime* | Timestamp when the dataset entered in the current status
-`user` <br> *user* <br> <em class="expandable">expandable</em> | User who started the action (currently not available in the API)
 
 ## Retrieve the current dataset status
 
@@ -88,6 +84,8 @@ curl https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXXXXX/st
 {
     "published": true,
     "status": "idle",
+    "previous": "processing",
+    "next": null,
     "since": "2015-04-15T15:13:04+00:00",
     "records_errors": [
         {
@@ -116,6 +114,8 @@ curl https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXXXXX/st
 {
     "published": true,
     "name": "idle",
+    "previous": "processing",
+    "next": null,
     "since": "2015-04-15T15:13:04+00:00",
     "records_errors": 45
 }
@@ -152,6 +152,8 @@ Transition destination status | Transition condition
 {
     "published": true,
     "name": "error",
+    "previous": "processing",
+    "next": null,
     "since": "2015-04-15T15:13:04+00:00",
     "message": "Processor pr_XXXXXX is misconfigured for field address: invalid type",
     "raw_message": "Processor {processor_id} is misconfigured for field {field}: {msg}",
@@ -194,6 +196,8 @@ Status | Condition
 ```json
 {
     "published": true,
+    "previous": "processing",
+    "next": null,
     "name": "limit_reached",
     "since": "2015-04-15T15:13:04+00:00"
 }
@@ -224,6 +228,8 @@ Status | Condition
 ```json
 {
     "published": true,
+    "previous": "idle",
+    "next": "processing",
     "name": "queued",
     "since": "2015-04-15T15:13:04+00:00"
 }
@@ -242,6 +248,8 @@ No specific attribute
 ```json
 {
     "published": true,
+    "previous": "queued",
+    "next": "idle",
     "name": "processsing",
     "since": "2015-04-15T15:13:04+00:00"
 }
@@ -272,6 +280,8 @@ Status | Condition
 ```json
 {
     "published": true,
+    "previous": "queued",
+    "next": "idle",
     "name": "deleting",
     "since": "2015-04-15T15:13:04+00:00"
 }
@@ -305,6 +315,8 @@ Status | Condition
 ```json
 {
     "published": true,
+    "previous": "processing",
+    "next": "idle",
     "name": "aborting_processing",
     "since": "2015-04-15T15:13:04+00:00"
 }

--- a/source/includes/_dataset_status.md
+++ b/source/includes/_dataset_status.md
@@ -2,6 +2,25 @@
 
 ## The dataset status object
 
+> Example object
+
+```json
+{
+  "name": "idle",
+  "previous": "processing",
+  "next": null,
+  "since": "2018-01-21T11:16:08.017412+00:00",
+  "published": true,
+  "records_errors": [],
+  "dataset": {
+    "dataset_uid": "da_7jgvnj",
+  }
+}
+```
+
+<aside class="notice">
+This API needs to be refactored into something clearer.
+</aside>
 The dataset status describes the current state of a dataset, stating if it's published or not and the running operation. It is a finite state machine, with the following properties:
 
 * a single state at a time
@@ -19,7 +38,7 @@ Attribute | Description
 `published` <br> *boolean* | true if the dataset is available in the search API
 `name` <br> *string* | One of the dataset status values
 `since` <br> *datetime* | Timestamp when the dataset entered in the current status
-`user` <br> *user* <br> <em class="expandable">expandable</em> | User who started the action
+`user` <br> *user* <br> <em class="expandable">expandable</em> | User who started the action (currently not available in the API)
 
 ## Retrieve the current dataset status
 

--- a/source/includes/_datasets.md
+++ b/source/includes/_datasets.md
@@ -41,7 +41,7 @@ Through the management API, it is possible to:
 Datasets are identified by 2 kinds of identifiers:
 
 - the `dataset_uid` that is automatically set, and will never change through the lifetime of the dataset.
-- the `dataset_id`, that can be chosen during dataset creation or changed on an unpublished dataset. It will be used in the exploration API and UI to access the dataset with a meaningful URL.
+- the `dataset_id`, that can be chosen during dataset creation or changed on an unpublished dataset. It will be used in the explore API and UI to access the dataset with a meaningful URL.
 
 ### Attributes
 
@@ -51,7 +51,7 @@ Attribute | Description
 `dataset_uid` <br> *string*      | Unique identifier of the dataset that will never change through the lifetime of the dataset
 `status` <br> *[dataset status object](#dataset-status)* <br> <em class="expandable">expandable</em> | Current status of the object
 `changes` <br> *Array of [dataset change objects](#dataset-changes)* <br> <em class="expandable">expandable</em> | List of all changes made to the current object
-`metas` <br> *[metadata object](#dataset-metadata)* | Dictionary of attributes about the dataset like a title, a description, keywords, that make it easily searchable through the portal's catalog
+`metas` <br> *[metadata object](#dataset-metadata)* <br> <em class="expandable">expandable</em> | Dictionary of attributes about the dataset like a title, a description, keywords, that make it easily searchable through the portal's catalog
 `last_modified` <br> *datetime*  | Date when the dataset's configuration was last edited
 `visibility` <br> *string*       | Defines if the dataset is visible for anonymous visitors <br> Can be `domain` if visibility is the same as the domain's visibility, or `restricted` if access is restricted to allowed users and groups
 
@@ -78,14 +78,6 @@ curl https://yourdomain.opendatasoft.com/api/management/v2/datasets/ \
         "dataset_id": "my-dataset",
         "dataset_uid": "da_xlnu9n",
         "metas": {
-            "default": {
-                "modified": "2017-08-27T20:17:30+00:00",
-                "language": "en",
-                "title": "My Dataset"
-            },
-            "publishing": {
-                "published": false
-            }
         },
         "last_modified": "2017-09-12T09:55:43.952561+00:00",
         "status": {
@@ -104,7 +96,7 @@ This endpoint lists all the datasets that can be edited by this user.
 Parameter | Default | Description
 --------- | ------- | -----------
 `where` <br> *string* | None | Filter expression used to restrict returned datasets ([ODSQL documentation](https://docs.opendatasoft.com/api/explore/v2.html#where-clause))
-`page` <br> *string* | 1 | Number of the page you want to retrieve. Pages numbers vary when changing the number of rows to retrieve.
+`page` <br> *string* | 1 | Number of the page you want to retrieve.
 `rows` <br> *string* | 10 | Number of items to return. Max value: 100
 `sort` <br> *string* | None | Field on which to sort the results list
 `include_app_metas` <br> *string* | false | Explicitely request application metadata for each datasets
@@ -128,7 +120,7 @@ GET https://{DOMAIN_ID}.opendatasoft.com/api/management/v2/datasets/{DATASET_UID
 > Example request
 
 ```shell
-curl 'https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_7jgvnj'
+curl 'https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_7jgvnj?expand=metas'
 ```
 
 > Example response

--- a/source/includes/_datasets.md
+++ b/source/includes/_datasets.md
@@ -41,7 +41,7 @@ Through the management API, it is possible to:
 Datasets are identified by 2 kinds of identifiers:
 
 - the `dataset_uid` that is automatically set, and will never change through the lifetime of the dataset.
-- the `dataset_id`, that can be chosen during dataset creation or changed on an unpublished dataset
+- the `dataset_id`, that can be chosen during dataset creation or changed on an unpublished dataset. It will be used in the exploration API and UI to access the dataset with a meaningful URL.
 
 ### Attributes
 
@@ -54,7 +54,6 @@ Attribute | Description
 `metas` <br> *[metadata object](#dataset-metadata)* | Dictionary of attributes about the dataset like a title, a description, keywords, that make it easily searchable through the portal's catalog
 `last_modified` <br> *datetime*  | Date when the dataset's configuration was last edited
 `visibility` <br> *string*       | Defines if the dataset is visible for anonymous visitors <br> Can be `domain` if visibility is the same as the domain's visibility, or `restricted` if access is restricted to allowed users and groups
-`status` <br> *[dataset status object](#dataset-status)* <br> <em class="expandable">expandable</em> | Keyword indicating if the dataset is waiting to be published, currently being published or if it encountered errors during last publishing
 
 ## List datasets
 
@@ -105,7 +104,7 @@ This endpoint lists all the datasets that can be edited by this user.
 Parameter | Default | Description
 --------- | ------- | -----------
 `where` <br> *string* | None | Filter expression used to restrict returned datasets ([ODSQL documentation](https://docs.opendatasoft.com/api/explore/v2.html#where-clause))
-`start` <br> *string* | 0 | Index of the first item to return
+`page` <br> *string* | 1 | Number of the page you want to retrieve. Pages numbers vary when changing the number of rows to retrieve.
 `rows` <br> *string* | 10 | Number of items to return. Max value: 100
 `sort` <br> *string* | None | Field on which to sort the results list
 `include_app_metas` <br> *string* | false | Explicitely request application metadata for each datasets
@@ -114,3 +113,43 @@ Parameter | Default | Description
 ### Returns
 
 Returns a list of dataset objects.
+
+
+## Retrieve information about one dataset
+
+This endpoint is for retrieving the dataset object with provided dataset_uid.
+
+> Definition
+
+```HTTP
+GET https://{DOMAIN_ID}.opendatasoft.com/api/management/v2/datasets/{DATASET_UID}
+```
+
+> Example request
+
+```shell
+curl 'https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_7jgvnj'
+```
+
+> Example response
+
+```json
+{
+    "dataset_id": "my-dataset",
+    "dataset_uid": "da_7jgvnj",
+    "metas": {
+        "default": {
+            "modified": "2017-08-27T20:17:30+00:00",
+            "language": "en",
+            "title": "My Dataset",
+        }
+    },
+    "last_modified": "2017-09-12T09:55:43.952561+00:00",
+    "status": {
+        "name": "idle"
+    },
+    "changes": [],
+    "visibility": "restricted",
+
+}
+```


### PR DESCRIPTION
- use page parameter instead of start for datasets list
- add the get dataset entry point
- remove duplicated dataset_status attribute in dataset object description
- add a dataset status object example
- add a notice for about dataset status API that will be modified