### PR TITLE
fix: typo in example api call

### DIFF
--- a/source/includes/_topics.md
+++ b/source/includes/_topics.md
@@ -5,7 +5,7 @@
 > Example authenticated request
 
 ```shell
-curl https://mydomain.opendatasoft.com/management/api/v2/datasets
+curl https://mydomain.opendatasoft.com/api/management/v2/datasets
   -u username:password
 ```
 


### PR DESCRIPTION
Not sure if I could directly commit this so here we are. 😅