### PR TITLE
Removed credentials object from docs

### DIFF
--- a/source/includes/_dataset_extractors.md
+++ b/source/includes/_dataset_extractors.md
@@ -37,7 +37,7 @@ curl -XGET https://yourdomain.opendatasoft.com/api/management/v2/extractors/
 }
 ```
 
-The enpoint returns the list of all available extractors, represented with their type, their label, their authentication mode and their available parameters.
+The endpoint returns the list of all available extractors, represented with their type, their label, their authentication mode, and their available parameters.
 
 ### Returns
 A list of extractors, represented by the following fields:
@@ -64,7 +64,7 @@ Parameter | Description
 
 ## Guess the right extractor for a source
 
-Before configuring a resource one must determine which extractor will perform well with the data source. In order to do that, this endpoint can be called with a URL (`odsfile` or remote).
+Before configuring a resource, one must determine which extractor will perform well with the data source. In order to do that, this endpoint can be called with a URL (`odsfile` or remote).
 
 > Definition
 
@@ -97,17 +97,16 @@ curl -XPOST https://yourdomain.opendatasoft.com/api/management/v2/guess_extracto
 }
 ```
 
-The endpoint takes an URL and optionally credentials to use in oder to gain access to this URL, and outputs a list of extractors that are likely to work well for this URL, as well as a list of the other extractors available on the domain that are not likely to succeed in extracting records out of that URL. 
+The endpoint takes an URL and outputs a list of extractors that are likely to work well for this URL, as well as a list of the other extractors available on the domain that are not likely to succeed in extracting records out of that URL.
 
 ### Parameters
 
 Parameter | Description
 --------- | -----------
 `url` | source URL <br> *string* can be remote (`ftp` or `https` for instance) or a local file with `odsfile`.
-`credentials` | credentials used to gain access to the source URL <br> *string*.
 
 ### Returns
-Returns a list of recommanded extractors filled with the extractor types that are likely to succeed at extracting records out of the URL as well as a list of all other extractors available on the platform that are not likely to do so.
+Returns a list of recommended extractors filled with the extractor types that are likely to succeed at extracting records out of the URL as well as a list of all other extractors available on the platform that are not likely to do so.
 
 
 ## Guess an extractor parameters

--- a/source/includes/_dataset_resources.md
+++ b/source/includes/_dataset_resources.md
@@ -2,7 +2,7 @@
 
 ## The resource object
 
-The resource object describes a resource on the Opendatasoft platform. It is composed of a URL, a title, a type, a parameter object and a credentials object. The URL is where data will be pulled to populate the dataset. Resources urls can (and often do!) point to [files](#files) uploaded to the platform using the `odsfile://` url scheme.
+The resource object describes a resource on the Opendatasoft platform. It is composed of a URL, a title, a type, and a parameter object. The URL is where data will be pulled to populate the dataset. Resources urls can (and often do!) point to [files](#files) uploaded to the platform using the `odsfile://` url scheme.
 
 ### Attributes
 
@@ -17,8 +17,7 @@ The resource object describes a resource on the Opendatasoft platform. It is com
     "params": {
         "headers_first_row": false,
         "separator": ";"
-    },
-    "credentials": {},
+    }
 }
 ```
 
@@ -29,7 +28,6 @@ Attribute | Description
 `title` <br> *string* | friendly title
 `type` <br> *[extractor](#extractors)* | extractor type that should handle this resource
 `params` <br> *object* | parameters passed to the extractor
-`credentials` <br> *object* | resource credentials
 
 ## List dataset resources
 
@@ -59,8 +57,7 @@ curl -XGET https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXX
     "params": {
         "headers_first_row": false,
         "separator": ";"
-    },
-    "credentials": {}
+    }
 }, {...}]
 ```
 
@@ -83,7 +80,7 @@ POST https://{YOURDOMAIN}.opendatasoft.com/api/management/v2/datasets/{DATASET_U
 ```HTTP
 curl -XPOST https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXXXXX/resources/
     -u username:password \
-    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}, "credentials": {} }'
+    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}}'
 ```
 
 > Example response
@@ -97,8 +94,7 @@ curl -XPOST https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XX
     "params": {
         "headers_first_row": false,
         "separator": ";"
-    },
-    "credentials": {}
+    }
 }
 ```
 
@@ -140,8 +136,7 @@ curl -XGET https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXX
     "params": {
         "headers_first_row": false,
         "separator": ";"
-    },
-    "credentials": {}
+    }
 }
 ```
 
@@ -185,7 +180,7 @@ PUT https://{YOURDOMAIN}.opendatasoft.com/api/management/v2/datasets/{DATASET_UI
 ```HTTP
 curl -XPUT https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXXXXX/resources/{RESOURCE_UID}
     -u username:password \
-    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}, "credentials": {} }'
+    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}}'
 
 ```
 
@@ -200,8 +195,7 @@ curl -XPUT https://yourdomain.opendatasoft.com/api/management/v2/datasets/da_XXX
     "params": {
         "headers_first_row": false,
         "separator": ";"
-    },
-    "credentials": {}
+    }
 }
 ```
 
@@ -236,7 +230,7 @@ GET https://{YOURDOMAIN}.opendatasoft.com/api/management/v2/datasets/da_XXXXXX/r
 ```HTTP
 curl -XPOST https://yourdomain.opendatasoft.com/api/management/v2/datasets/{DATASET_UID}/resource_preview
     -u username:password \
-    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}, "credentials": {} }'
+    -d '{ "url": "odsfile://resource.csv", "title": "My Awesome Data File", "type": "csvfile", "params": {"headers_first_row": false, "separator": ";"}}'
 ```
 
 > Example UID-based request


### PR DESCRIPTION
## Summary

This pull request removes the `credentials` objects from the documentation because this object does not exist anymore.

Story details: https://app.clubhouse.io/opendatasoft/story/28015

## Changes 

- Removed the `credentials` object from descriptions and examples included in the Dataset Resources sections.